### PR TITLE
Replace all desktop/copilot-release-notes references with github/

### DIFF
--- a/.github/workflows/test-cli-generic.yml
+++ b/.github/workflows/test-cli-generic.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Generate Release Notes (Generic)
         id: notes
-        uses: desktop/copilot-release-notes@main
+        uses: github/copilot-release-notes@main
         with:
           base-ref: ${{ inputs.base-ref }}
           head-ref: ${{ inputs.head-ref }}

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -30,13 +30,13 @@ jobs:
       - name: Checkout instructions file
         uses: actions/checkout@v4
         with:
-          repository: desktop/copilot-release-notes
+          repository: github/copilot-release-notes
           path: _action-config
           sparse-checkout: cli-release-notes-instructions.md
 
       - name: Generate Release Notes (CLI Style)
         id: notes
-        uses: desktop/copilot-release-notes@main
+        uses: github/copilot-release-notes@main
         with:
           base-ref: ${{ inputs.base-ref }}
           head-ref: ${{ inputs.head-ref }}

--- a/.github/workflows/test-custom.yml
+++ b/.github/workflows/test-custom.yml
@@ -30,13 +30,13 @@ jobs:
       - name: Checkout instructions file
         uses: actions/checkout@v4
         with:
-          repository: desktop/copilot-release-notes
+          repository: github/copilot-release-notes
           path: _action-config
           sparse-checkout: release-notes-guide.md
 
       - name: Generate Release Notes (Custom Instructions)
         id: notes
-        uses: desktop/copilot-release-notes@main
+        uses: github/copilot-release-notes@main
         with:
           base-ref: ${{ inputs.base-ref }}
           head-ref: ${{ inputs.head-ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Generate Release Notes
         id: notes
-        uses: desktop/copilot-release-notes@main
+        uses: github/copilot-release-notes@main
         with:
           base-ref: ${{ inputs.base-ref }}
           head-ref: ${{ inputs.head-ref }}


### PR DESCRIPTION
Updates all workflow files to point to `github/copilot-release-notes` instead of `desktop/copilot-release-notes`. The desktop repo is being deleted.