### PR TITLE
Add self-dogfooding release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@v4
@@ -52,6 +53,7 @@ jobs:
           base-ref: ${{ steps.version.outputs.previous }}
           head-ref: ${{ github.sha }}
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
 
       - name: Create GitHub Release
@@ -61,8 +63,9 @@ jobs:
           name: ${{ steps.version.outputs.next }}
           body: ${{ steps.notes.outputs.release-notes }}
           draft: true
+          target_commitish: ${{ github.sha }}
 
       - name: Update major version tag
         run: |
-          git tag -f "${{ steps.version.outputs.major }}" "${{ steps.version.outputs.next }}"
-          git push origin "${{ steps.version.outputs.major }}" --force
+          git tag -f "${{ steps.version.outputs.major }}" "${{ github.sha }}"
+          git push origin "refs/tags/${{ steps.version.outputs.major }}" --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       bump:
         description: 'Version bump type'
         required: true
+        default: 'patch'
         type: choice
         options:
           - patch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,14 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Release version (e.g., v1.2.0)'
+      bump:
+        description: 'Version bump type'
         required: true
-      base-ref:
-        description: 'Previous release tag (e.g., v1.1.0)'
-        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
   release:
@@ -21,11 +23,32 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Determine versions
+        id: version
+        run: |
+          LATEST=$(git tag --list 'v*.*.*' --sort=-v:refname | head -n 1)
+          if [ -z "$LATEST" ]; then
+            LATEST="v0.0.0"
+          fi
+          echo "previous=$LATEST" >> "$GITHUB_OUTPUT"
+
+          # Strip 'v' prefix, split, bump, reassemble
+          IFS='.' read -r MAJOR MINOR PATCH <<< "${LATEST#v}"
+          case "${{ inputs.bump }}" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+          esac
+          NEXT="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "major=v${MAJOR}" >> "$GITHUB_OUTPUT"
+          echo "Releasing $NEXT (previous: $LATEST)"
+
       - name: Generate release notes
         id: notes
         uses: github/copilot-release-notes@v1
         with:
-          base-ref: ${{ inputs.base-ref }}
+          base-ref: ${{ steps.version.outputs.previous }}
           head-ref: ${{ github.sha }}
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
@@ -33,13 +56,12 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ inputs.version }}
-          name: ${{ inputs.version }}
+          tag_name: ${{ steps.version.outputs.next }}
+          name: ${{ steps.version.outputs.next }}
           body: ${{ steps.notes.outputs.release-notes }}
           draft: true
 
       - name: Update major version tag
         run: |
-          MAJOR=$(echo "${{ inputs.version }}" | grep -oE '^v[0-9]+')
-          git tag -f "$MAJOR" "${{ inputs.version }}"
-          git push origin "$MAJOR" --force
+          git tag -f "${{ steps.version.outputs.major }}" "${{ steps.version.outputs.next }}"
+          git push origin "${{ steps.version.outputs.major }}" --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., v1.2.0)'
+        required: true
+      base-ref:
+        description: 'Previous release tag (e.g., v1.1.0)'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate release notes
+        id: notes
+        uses: github/copilot-release-notes@v1
+        with:
+          base-ref: ${{ inputs.base-ref }}
+          head-ref: ${{ github.sha }}
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.version }}
+          name: ${{ inputs.version }}
+          body: ${{ steps.notes.outputs.release-notes }}
+          draft: true
+
+      - name: Update major version tag
+        run: |
+          MAJOR=$(echo "${{ inputs.version }}" | grep -oE '^v[0-9]+')
+          git tag -f "$MAJOR" "${{ inputs.version }}"
+          git push origin "$MAJOR" --force


### PR DESCRIPTION
Adds a `workflow_dispatch` release workflow that uses this action to generate its own release notes. 🐕

**How it works:**
1. Go to Actions → Release → Run workflow
2. Pick **patch**, **minor**, or **major** from the dropdown (defaults to patch)
3. Auto-detects the latest release tag and calculates the next version
4. Runs `github/copilot-release-notes@v1` against itself to generate notes from all PRs since the last release
5. Creates a **draft** GitHub Release (so you can review before publishing)
6. Updates the floating major version tag (e.g., `v1`)