### PR TITLE
Add explicit permissions to test workflows

### DIFF
--- a/.github/workflows/test-cli-generic.yml
+++ b/.github/workflows/test-cli-generic.yml
@@ -12,6 +12,10 @@ on:
         required: true
         default: 'v2.89.0'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   test-cli-generic:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -12,6 +12,10 @@ on:
         required: true
         default: 'v2.89.0'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   test-cli:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-custom.yml
+++ b/.github/workflows/test-custom.yml
@@ -12,6 +12,10 @@ on:
         required: true
         default: 'release-3.5.7-beta1'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   test-custom:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ on:
         required: true
         default: 'release-3.5.7-beta1'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   test-generate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add explicit `permissions` blocks to all four test workflows that were missing them, restricting the `GITHUB_TOKEN` to the minimum required scope.

### Changes

All four test workflows now declare:
```yaml
permissions:
  contents: read
  pull-requests: read
```

- `contents: read` — needed for repository checkout
- `pull-requests: read` — needed because the action fetches PR metadata via `octokit.rest.pulls.get`

### Code Scanning Alerts Fixed

- https://github.com/github/copilot-release-notes/security/code-scanning/1
- https://github.com/github/copilot-release-notes/security/code-scanning/2
- https://github.com/github/copilot-release-notes/security/code-scanning/3
- https://github.com/github/copilot-release-notes/security/code-scanning/4

`release.yml` already had an explicit permissions block and required no changes.