### PR TITLE
Use workflow token for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
+      copilot-requests: write
       contents: write
       pull-requests: read
 
@@ -54,7 +55,6 @@ jobs:
           head-ref: ${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,6 @@ jobs:
           tag_name: ${{ steps.version.outputs.next }}
           name: ${{ steps.version.outputs.next }}
           body: ${{ steps.notes.outputs.release-notes }}
-          draft: true
           target_commitish: ${{ github.sha }}
 
       - name: Update major version tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ on:
           - patch
           - minor
           - major
+      draft:
+        description: 'Create the release as a draft'
+        required: true
+        default: false
+        type: boolean
 
 jobs:
   release:
@@ -62,6 +67,7 @@ jobs:
           tag_name: ${{ steps.version.outputs.next }}
           name: ${{ steps.version.outputs.next }}
           body: ${{ steps.notes.outputs.release-notes }}
+          draft: ${{ inputs.draft }}
           target_commitish: ${{ github.sha }}
 
       - name: Update major version tag


### PR DESCRIPTION
## Summary

- grant the release job `copilot-requests: write`
- authenticate Copilot CLI with the built-in `${{ github.token }}`
- remove the nonexistent `COPILOT_GITHUB_TOKEN` secret dependency
- publish releases immediately by default, with an optional `draft` workflow input

## Validation

- parsed and inspected the workflow authentication and release configuration
- verified the published `v1` action supports falling back to `GITHUB_TOKEN`
- verified version calculations produce `v1.0.3`, `v1.1.0`, and `v2.0.0` from `v1.0.2`
- verified the boolean `draft` input defaults to `false` and controls release creation
- PR end-to-end CI exercises Copilot authentication with the same workflow-token permission

The release workflow has never run, so creating a release and moving tags cannot be fully exercised without performing a real release.